### PR TITLE
Example for `extractManualRecode()`

### DIFF
--- a/R/extractManualRecode.R
+++ b/R/extractManualRecode.R
@@ -4,7 +4,19 @@
 #' @param varName Character string for the column containing the automatically recoded values.
 #' @return Returns a data frame which only includes the values that have to be recoded manually. It can be saved to Excel for manual recoding.
 #'
-#' @examples # tbd
+#' @examples
+#' # example data frame
+#' df <- data.frame(id = 1:4,
+#'                  country = c("Germany", "Scotland", NA , "Egypt"),
+#'                  capital = c("Berlin", "Edinburgh", "Stockholm", "Cairo"))
+#' # extract values to recode manually
+#' manual_recodes <- extractManualRecode(recodedList = df, varName = "country")
+#' print(manual_recodes)
+#' # export to Excel, edit, import
+#' tmp <- writexl::write_xlsx(manual_recodes, path = "manual_recodes.xlsx")
+#' readxl::read_xlsx(tmp)
+#' file.remove(tmp)
+#'
 #' @export
 extractManualRecode <- function(recodedList, varName) {
   # Check input object type -------------------------------------------------

--- a/R/extractManualRecode.R
+++ b/R/extractManualRecode.R
@@ -1,8 +1,8 @@
 #' Get manual recodes
 #'
-#' @param recodedList A data frame with the automatically recoded values.+
+#' @param recodedList A data frame with the automatically recoded values.
 #' @param varName Character string for the column containing the automatically recoded values.
-#' @return Returns a data frame which only includes the values that have to be recoded manually. It can be saved to excel for manual recoding.
+#' @return Returns a data frame which only includes the values that have to be recoded manually. It can be saved to Excel for manual recoding.
 #'
 #' @examples # tbd
 #' @export

--- a/man/extractManualRecode.Rd
+++ b/man/extractManualRecode.Rd
@@ -7,16 +7,27 @@
 extractManualRecode(recodedList, varName)
 }
 \arguments{
-\item{recodedList}{A data frame with the automatically recoded values.+}
+\item{recodedList}{A data frame with the automatically recoded values.}
 
 \item{varName}{Character string for the column containing the automatically recoded values.}
 }
 \value{
-Returns a data frame which only includes the values that have to be recoded manually. It can be saved to excel for manual recoding.
+Returns a data frame which only includes the values that have to be recoded manually. It can be saved to Excel for manual recoding.
 }
 \description{
 Get manual recodes
 }
 \examples{
-# tbd
+# example data frame
+df <- data.frame(id = 1:4,
+                 country = c("Germany", "Scotland", NA , "Egypt"),
+                 capital = c("Berlin", "Edinburgh", "Stockholm", "Cairo"))
+# extract values to recode manually
+manual_recodes <- extractManualRecode(recodedList = df, varName = "country")
+print(manual_recodes)
+# export to excel, edit, import
+tmp <- writexl::write_xlsx(manual_recodes, path = "manual_recodes.xlsx")
+readxl::read_xlsx(tmp)
+file.remove(tmp)
+
 }


### PR DESCRIPTION
Ich habe ein Beispiel für extractManualRecode() hinzugefügt. Dieses enthält auch das Exportieren und Importieren des erstellten Datensatzes als Excel_Datei, um den kompletten Workflow mit extractManualRecode() abzubilden. Orientiert habe ich mich dabei an den examples im "readxl" package. Ist das beim Schreiben von examples so üblich, oder soll eher nur die Benutzung der dokumentierten Funktion selbst gezeigt werden?