### PR TITLE
improve error message updateRecodeDB()

### DIFF
--- a/R/updateRecodeDB.R
+++ b/R/updateRecodeDB.R
@@ -54,7 +54,9 @@ updateRecodeDB <- function(newRecodes, oldValues = "oldValues", newValues = "new
                            DBname, newDBname = DBname, ListName,
                            fileType = "csv2", replace = FALSE) {
   # checks
-  checkmate::assert_subset(c(oldValues, newValues), choices = colnames(newRecodes))
+  if(!checkmate::test_subset(c(oldValues, newValues), choices = colnames(newRecodes))){
+    stop("Your data.frame `newRecodes` must contain the columns `oldValues` and `newValues`.")
+  }
 
   if(!fileType %in% c("xlsx","csv","csv2")) {stop("FileType must be `csv2`, `csv`, or `xlsx`.")}
 

--- a/R/updateRecodeDB.R
+++ b/R/updateRecodeDB.R
@@ -54,7 +54,7 @@ updateRecodeDB <- function(newRecodes, oldValues = "oldValues", newValues = "new
                            DBname, newDBname = DBname, ListName,
                            fileType = "csv2", replace = FALSE) {
   # checks
-  checkmate::assert_subset(colnames(newRecodes), choices = c(oldValues, newValues))
+  checkmate::assert_subset(c(oldValues, newValues), choices = colnames(newRecodes))
 
   if(!fileType %in% c("xlsx","csv","csv2")) {stop("FileType must be `csv2`, `csv`, or `xlsx`.")}
 

--- a/R/updateRecodeDB.R
+++ b/R/updateRecodeDB.R
@@ -53,6 +53,8 @@ updateRecodeDB <- function(newRecodes, oldValues = "oldValues", newValues = "new
                            directory, newDirectory = directory,
                            DBname, newDBname = DBname, ListName,
                            fileType = "csv2", replace = FALSE) {
+  # checks
+  checkmate::assert_subset(colnames(newRecodes), choices = c(oldValues, newValues))
 
   if(!fileType %in% c("xlsx","csv","csv2")) {stop("FileType must be `csv2`, `csv`, or `xlsx`.")}
 


### PR DESCRIPTION
current error message with assert_subset:

> Assertion on 'colnames(newRecodes)' failed: Must be a subset of {'oldValues','newValues'}, but has additional elements {'a','b'}

is that enough or should I look into customizing error messages?